### PR TITLE
Don't throw exceptions when write() returns false

### DIFF
--- a/server/src/process/process.ts
+++ b/server/src/process/process.ts
@@ -66,19 +66,9 @@ export class ProcessWrapper {
     }
     private writeRequestToServer(request: string, verb: string, serverEndTag: string,
                                  commandFailedMessage: string, requestFailedMessage: string): void {
-        let good: boolean = this.serverProc.stdin.write(verb + "\n", () => {
-            if (!good) {
-                throw new CommandFailedException(commandFailedMessage);
-            }
-            good = this.serverProc.stdin.write(request + "\n", () => {
-                if (!good) {
-                    throw new RequestFailedException(requestFailedMessage);
-                }
-                good = this.serverProc.stdin.write(serverEndTag + "\n", () => {
-                    if (!good) {
-                        throw new CommandEndFailedException(commandFailedMessage);
-                    }
-                });
+        this.serverProc.stdin.write(verb + "\n", () => {
+            this.serverProc.stdin.write(request + "\n", () => {
+                this.serverProc.stdin.write(serverEndTag + "\n", () => {});
             });
         });
     }


### PR DESCRIPTION
Fixes #8.

This is a quick fix that ignores `write`'s return value. This means that the buffer may grow arbitrarily large, but I expect that this will not be a problem in practice, since requests are not submitted to the language server very quickly. 